### PR TITLE
Factorize tables

### DIFF
--- a/src/Base32.php
+++ b/src/Base32.php
@@ -19,86 +19,11 @@ namespace Base32;
 class Base32
 {
     /**
-     * Table for encoding base32
+     * Alphabet for encoding and decoding base32
      *
      * @var array
      */
-    private static $encode = array(
-        0 => 'A',
-        1 => 'B',
-        2 => 'C',
-        3 => 'D',
-        4 => 'E',
-        5 => 'F',
-        6 => 'G',
-        7 => 'H',
-        8 => 'I',
-        9 => 'J',
-        10 => 'K',
-        11 => 'L',
-        12 => 'M',
-        13 => 'N',
-        14 => 'O',
-        15 => 'P',
-        16 => 'Q',
-        17 => 'R',
-        18 => 'S',
-        19 => 'T',
-        20 => 'U',
-        21 => 'V',
-        22 => 'W',
-        23 => 'X',
-        24 => 'Y',
-        25 => 'Z',
-        26 => 2,
-        27 => 3,
-        28 => 4,
-        29 => 5,
-        30 => 6,
-        31 => 7,
-        32 => '=',
-    );
-
-    /**
-     * Table for decoding base32
-     *
-     * @var array
-     */
-    private static $decode = array(
-        'A' => 0,
-        'B' => 1,
-        'C' => 2,
-        'D' => 3,
-        'E' => 4,
-        'F' => 5,
-        'G' => 6,
-        'H' => 7,
-        'I' => 8,
-        'J' => 9,
-        'K' => 10,
-        'L' => 11,
-        'M' => 12,
-        'N' => 13,
-        'O' => 14,
-        'P' => 15,
-        'Q' => 16,
-        'R' => 17,
-        'S' => 18,
-        'T' => 19,
-        'U' => 20,
-        'V' => 21,
-        'W' => 22,
-        'X' => 23,
-        'Y' => 24,
-        'Z' => 25,
-        2 => 26,
-        3 => 27,
-        4 => 28,
-        5 => 29,
-        6 => 30,
-        7 => 31,
-        '=' => 32,
-    );
+    private static $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567=';
 
     /**
      * Creates an array from a binary string into a given chunk size
@@ -162,7 +87,7 @@ class Base32
             }
 
             // Base32 character
-            $base32String .= self::$encode[$char];
+            $base32String .= substr(self::$alphabet, $char, 1);
         }
 
         return $base32String;
@@ -194,7 +119,7 @@ class Base32
         $string = '';
 
         foreach ($base32Array as $str) {
-            $char = self::$decode[$str];
+            $char = strpos(self::$alphabet, $str);
 
             // Ignore the padding character
             if ($char !== 32) {


### PR DESCRIPTION
No need to declare 2 arrays when a simple alphabet is sufficient.