### PR TITLE
dev dependencies modified

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,23 @@
 language: php
 
+sudo: false
+
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
+    - 5.6
+    - 7.0
+    - hhvm
+    - nightly
+
+matrix:
+    allow_failures:
+        - nightly
 
 before_script:
-  - composer install
+    - composer install
 
 before_script:
-    - curl -s http://getcomposer.org/installer | php
-    - php composer.phar update --dev --no-interaction
+    - composer install --no-interaction
     - mkdir -p build/logs
 
 script:
-    - php vendor/bin/phpunit --coverage-text
+    - vendor/bin/phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 base32
 ======
 
-Base32 Encoder/Decoder for PHP according to RFC 4648
+Base32 Encoder/Decoder for PHP according to [RFC 4648](https://tools.ietf.org/html/rfc4648).
 
 [![Build Status](https://secure.travis-ci.org/ChristianRiesen/base32.png)](http://travis-ci.org/ChristianRiesen/base32)
 [![HHVM Status](http://hhvm.h4cc.de/badge/christian-riesen/base32.png)](http://hhvm.h4cc.de/package/christian-riesen/base32)
@@ -15,19 +15,20 @@ Do you like this? Flattr it:
 Usage
 -----
 
-    <?php
+```php
+<?php
 
-    // Include class or user autoloader
-    use Base32\Base32;
+// Include class or user autoloader
+use Base32\Base32;
 
-    $string = 'fooba';
+$string = 'fooba';
 
-    $encoded = Base32::encode($string);
-    // $encoded contains now 'MZXW6YTB'
+$encoded = Base32::encode($string);
+// $encoded contains now 'MZXW6YTB'
 
-    $decoded = Base32::decode($encoded);
-    // $decoded is again 'fooba'
-
+$decoded = Base32::decode($encoded);
+// $decoded is again 'fooba'
+```
 
 About
 =====
@@ -44,9 +45,9 @@ Have a RFC compliant Base32 encoder and decoder. The implementation could be imp
 Requirements
 ------------
 
-PHP 5.3.x+
+PHP 5.3 to 5.6 or 7.0+
 
-If you want to run the tests, PHPUnit 3.6 or up is required.
+If you want to run the tests, PHPUnit 5.0+ or up is required. Tests require PHP 5.6 or 7.0+.
 
 Author
 ------
@@ -57,4 +58,3 @@ Acknowledgements
 ----------------
 
 Base32 is mostly based on the work of https://github.com/NTICompass/PHP-Base32
-

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["base32","encode","decode","rfc4648"],
     "homepage": "https://github.com/ChristianRiesen/base32",
     "license": "MIT",
-	"authors": [
+    "authors": [
         {
             "name": "Christian Riesen",
             "email": "chris.riesen@gmail.com",
@@ -14,13 +14,14 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*",
-        "satooshi/php-coveralls": "0.*"
+        "php": ">=5.6",
+        "phpunit/phpunit": "^5.0",
+        "satooshi/php-coveralls": "^1.0"
     },
-	"autoload": {
+   "autoload": {
         "psr-4": {
             "Base32\\": "src/"
         }


### PR DESCRIPTION
This PR adds tests on PHP 7.0 and add PHP 5.6 as minimal requirement (lower versions are/will be unsupported).
It includes minor modifications on the documenation.