### PR TITLE
Bugfix: use correct value for n when evaluating if character is padding or actually zero

### DIFF
--- a/src/Base32.php
+++ b/src/Base32.php
@@ -105,7 +105,7 @@ class Base32
                 $val += $chars[$n];
             }
             $shift = $bitLen - 5;
-            $encoded .= ($n >= $len && 0 == $val) ? '=' : static::ALPHABET[$val >> $shift];
+            $encoded .= ($n - (int)($bitLen > 8) > $len && 0 == $val) ? '=' : static::ALPHABET[$val >> $shift];
             $val = $val & ((1 << $shift) - 1);
             $bitLen -= 5;
         }

--- a/tests/Base32Test.php
+++ b/tests/Base32Test.php
@@ -35,6 +35,7 @@ class Base32Test extends TestCase
             'Empty String' => ['', ''],
             'All Invalid Characters' => ['', '8908908908908908'],
             'Random Integers' => [\base64_decode('HgxBl1kJ4souh+ELRIHm/x8yTc/cgjDmiCNyJR/NJfs='), 'DYGEDF2ZBHRMULUH4EFUJAPG74PTETOP3SBDBZUIENZCKH6NEX5Q===='],
+            'Partial zero edge case' => ["8", "HA======"],
         ];
 
         return \array_merge($encodeData, self::RFC_VECTORS);
@@ -48,6 +49,7 @@ class Base32Test extends TestCase
         $encodeData = [
             'Empty String' => ['', ''],
             'Random Integers' => [\base64_decode('HgxBl1kJ4souh+ELRIHm/x8yTc/cgjDmiCNyJR/NJfs='), 'DYGEDF2ZBHRMULUH4EFUJAPG74PTETOP3SBDBZUIENZCKH6NEX5Q===='],
+            'Partial zero edge case' => ["8", "HA======"],
         ];
 
         return \array_merge($encodeData, self::RFC_VECTORS);


### PR DESCRIPTION
If val==0, but bitLen<5, it would read an extra character and increment n. Since n is only wrong when bitLen>8 after reading, we can subtract one to fix n and correctly print 'A' not '='. Adds test case.
Fixes #28 