### PR TITLE
Remove composer.json from .gitattributes export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 .github/ export-ignore
 .gitignore export-ignore
 .php_cs.dist export-ignore
-composer.json export-ignore
 phpstan.neon export-ignore
 phpunit.xml.dist export-ignore
 tests/ export-ignore


### PR DESCRIPTION
It is recommended to include the `composer.json` if the repository is intended to be used as a Composer package (e.g., distributed via Packagist).

#36
sonatype/nexus-public#640